### PR TITLE
Fixed undefined analysis variable in crossfades.

### DIFF
--- a/src/echonest/action.py
+++ b/src/echonest/action.py
@@ -147,7 +147,7 @@ class Crossfade(object):
         return audio_out
     
     def __repr__(self):
-        args = (analysis.pyechonest_track.title, self.t2.track.analysis.pyechonest_track.title)
+        args = (self.t1.track.analysis.pyechonest_track.title, self.t2.track.analysis.pyechonest_track.title)
         return "<Crossfade '%s' and '%s'>" % args
     
     def __str__(self):


### PR DESCRIPTION
Just ran into a `NameError: global name 'analysis' is not defined` when playing around with the `action` package. This fixes it.
