### PR TITLE
Allowing unicode filenames

### DIFF
--- a/src/echonest/remix/audio.py
+++ b/src/echonest/remix/audio.py
@@ -90,7 +90,7 @@ class AudioAnalysis(object):
         .. _Echo Nest: http://the.echonest.com/
         """
         
-        if type(path_or_identifier) is not str:
+        if type(path_or_identifier) not in [str, unicode]:
             # Argument is invalid.
             raise TypeError("Argument 'path_or_identifier' must be a string \
                             representing either a filename, track ID, or MD5.")


### PR DESCRIPTION
This makes it so that an exception isn't raised if the path or id provided to the `AudioAnalysis` object is `unicode` instead of `str`. It's definitely _not_ a vital change but I generally work with unicode strings internally so this would just be a little nicer for me. I don't think that this should break anything.

Thanks for this awesome API/module!
