### PR TITLE
Removed flag in setup.py for clang compatibility

### DIFF
--- a/external/pysoundtouch14/setup.py
+++ b/external/pysoundtouch14/setup.py
@@ -29,7 +29,7 @@ extra_compile_args = []
 # Is this is posix platform, or is it windows?
 if hasattr(os, 'uname'):
     sources += sources_gcc
-    extra_compile_args=['-fcheck-new', '-O3', 
+    extra_compile_args=['-O3', 
                         '-I', '/System/Library/Frameworks/Python.framework/Versions/2.5/Extras/lib/python/numpy/core/include',    # mac
                         '-I', '/System/Library/Frameworks/Python.framework/Versions/2.5/Extras/lib/python/numpy/numarray',        # mac
 			            '-I', '/usr/lib/python2.5/site-packages/numpy/numarray/numpy']                                            # lin


### PR DESCRIPTION
Fixes error when building with clang (Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn))

Error shown below:

clang -fno-strict-aliasing -fno-common -dynamic -I/usr/local/include -I/usr/local/opt/sqlite/include -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/lib/python2.7/site-packages/numpy/core/include -I/usr/local/lib/python2.7/site-packages/numpy/numarray/include -I/usr/local/Cellar/python/2.7.6_1/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c external/pysoundtouch14/libsoundtouch/AAFilter.cpp -o build/temp.macosx-10.8-x86_64-2.7/external/pysoundtouch14/libsoundtouch/AAFilter.o -fcheck-new -O3 -Wno-unused

clang: error: unknown argument: '-fcheck-new' [-Wunused-command-line-argument-hard-error-in-future]

clang: note: this will be a hard error (cannot be downgraded to a warning) in the future

error: command 'clang' failed with exit status 1
