### PR TITLE
Remove -fcheck-new arguments causing crashes on Xcode >5.1

### DIFF
--- a/external/pysoundtouch14/setup.py
+++ b/external/pysoundtouch14/setup.py
@@ -29,7 +29,7 @@ extra_compile_args = []
 # Is this is posix platform, or is it windows?
 if hasattr(os, 'uname'):
     sources += sources_gcc
-    extra_compile_args=['-fcheck-new', '-O3', 
+    extra_compile_args=['-O3', 
                         '-I', '/System/Library/Frameworks/Python.framework/Versions/2.5/Extras/lib/python/numpy/core/include',    # mac
                         '-I', '/System/Library/Frameworks/Python.framework/Versions/2.5/Extras/lib/python/numpy/numarray',        # mac
 			            '-I', '/usr/lib/python2.5/site-packages/numpy/numarray/numpy']                                            # lin

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def get_soundtouch():
 
     if is_linux:
         sources += ['cpu_detect_x86_gcc.cpp']
-        extra_compile_args = ['-fcheck-new', '-O3', '-Wno-unused']
+        extra_compile_args = ['-O3', '-Wno-unused']
     if is_mac:
         sources += ['cpu_detect_x86_gcc.cpp']
         extra_compile_args = ['-O3', '-Wno-unused']


### PR DESCRIPTION
According to  Xcode Release Notes:
The Apple LLVM compiler in Xcode 5.1 treats unrecognized command-line options as errors.

Since according to http://gcc.gnu.org/onlinedocs/gcc-3.4.5/gcc/C_002b_002b-Dialect-Options.html
the -fcheck-new is normally unecessary we actually don't need it.

Change-Id: I0ea9e9aa7d95eaa3e12136ba190370b114e74992
