### PR TITLE
Added quotes around filepaths parameters in ffmpeg calls

### DIFF
--- a/src/echonest/remix/video.py
+++ b/src/echonest/remix/video.py
@@ -301,7 +301,7 @@ def sequencefrommov(mov, settings=None, direc=None, pre="frame-", verbose=True):
     format = "jpeg"
     if settings is not None:
         format = settings.imageformat()
-    cmd = "en-ffmpeg -i " + mov + " -an -sameq " + os.path.join(direc, pre + "%06d." + format)
+    cmd = "en-ffmpeg -i \"" + mov + "\" -an -sameq " + os.path.join(direc, pre + "%06d." + format)
     if verbose:
         log.info(cmd)
     out = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
@@ -316,7 +316,7 @@ def sequencetomovie(outfile, seq, audio=None, verbose=True):
     "renders sequence to a movie file, perhaps with an audio track"
     direc = tempfile.mkdtemp()
     seq.render(direc, "image-", False)
-    cmd = "en-ffmpeg -y " + str(seq.settings) + " -i " + os.path.join(direc, "image-%06d." + seq.settings.imageformat())
+    cmd = "en-ffmpeg -y \"" + str(seq.settings) + "\" -i " + os.path.join(direc, "image-%06d." + seq.settings.imageformat())
     if audio:
         cmd += " -i " + audio
     cmd += " -sameq " + outfile
@@ -340,7 +340,7 @@ def convertmov(infile, outfile=None, settings=None, verbose=True):
         raise TypeError("settings arg must be a VideoSettings object")
     if outfile is None:
         foo, outfile = tempfile.mkstemp(".flv")
-    cmd = "en-ffmpeg -y -i " + infile + " " + str(settings) + " -sameq " + outfile
+    cmd = "en-ffmpeg -y -i \"" + infile + "\" " + str(settings) + " -sameq \"" + outfile + "\""
     if verbose:
         log.info(cmd)
     out = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)

--- a/src/echonest/remix/video.py
+++ b/src/echonest/remix/video.py
@@ -316,10 +316,10 @@ def sequencetomovie(outfile, seq, audio=None, verbose=True):
     "renders sequence to a movie file, perhaps with an audio track"
     direc = tempfile.mkdtemp()
     seq.render(direc, "image-", False)
-    cmd = "en-ffmpeg -y \"" + str(seq.settings) + "\" -i " + os.path.join(direc, "image-%06d." + seq.settings.imageformat())
+    cmd = "en-ffmpeg -y " + str(seq.settings) + " -i " + os.path.join(direc, "image-%06d." + seq.settings.imageformat())
     if audio:
-        cmd += " -i " + audio
-    cmd += " -sameq " + outfile
+        cmd += " -i \"" + audio + "\""
+    cmd += " -sameq \"" + outfile + "\""
     if verbose:
         log.info(cmd)
     out = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)


### PR DESCRIPTION
Filepaths with spaces weren't escaped properly in ffmpeg calls on Windows.

I added quotes around filepaths to fix the issue. They were already in loadav, but not in the other functions.