### PR TITLE
Add CPP warning overrides to fix Ubuntu 13.04+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def get_action():
 
 def get_dirac():
     link_args = ['-framework', 'Carbon'] if is_mac else []
-    compile_args = [] if is_windows else ['-Wno-unused']
+    compile_args = [] if is_windows else ['-Wno-unused', '-Wno-format-security']
 
     pydirac = os.path.join('external', 'pydirac225')
     lib_sources = [os.path.join(pydirac, 'diracmodule.cpp'), os.path.join(pydirac, 'source', 'Dirac_LE.cpp')]
@@ -77,7 +77,7 @@ def get_soundtouch():
 
     if is_linux:
         sources += ['cpu_detect_x86_gcc.cpp']
-        extra_compile_args = ['-O3', '-Wno-unused']
+        extra_compile_args = ['-O3', '-Wno-unused','-Wno-format-security']
     elif is_mac:
         sources += ['cpu_detect_x86_gcc.cpp']
         extra_compile_args = ['-O3', '-Wno-unused']


### PR DESCRIPTION
Obviously, the root cause should be addressed but it's a dependency.
Looks like Ubuntu 13.04 turned this on by default:
https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-Wformat_-Wformat-security

`setup.py` now builds fine for me.

Fixes #45.
